### PR TITLE
fixed main file path

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "flippy.js",
   "version": "1.0.2",
   "description": "FLIP animation helper; animate DOM changes with ease",
-  "main": "dist/flippy.js",
+  "main": "dist/flippy.bundle.js",
   "keywords": [
     "flip",
     "animation"


### PR DESCRIPTION
Tried to use it today, installed via npm and bundle via webpack.
Webpack couldn't resolve the package because the main filename was wrong.

Fixed it in this PR.
